### PR TITLE
Add configurable loan tracking and audit endpoints

### DIFF
--- a/app/loan.py
+++ b/app/loan.py
@@ -1,25 +1,47 @@
 # app/loan.py
 import time
 from contextlib import contextmanager
+from typing import List, Optional
+
 
 class RevertableLoanError(Exception):
     pass
 
 
 @contextmanager
-def flash_loan(limit_gbp: float, timeout_s: int = 30):
-    """
-    Pretend we just borrowed `limit_gbp` with zero collateral.
-    If the caller fails to repay by exiting the context, we raise.
-    """
+def flash_loan(
+    limit_gbp: float,
+    timeout_s: int = 30,
+    principal_asset: str = "gbp",
+    repayment_assets: Optional[List[str]] = None,
+):
+    """Simulate a multi-asset flash-loan ledger."""
+
+    if repayment_assets:
+        seen: List[str] = []
+        for asset in repayment_assets:
+            if asset not in seen:
+                seen.append(asset)
+        assets = seen
+    else:
+        assets = [principal_asset]
+    if principal_asset not in assets:
+        assets.insert(0, principal_asset)
+
     start = time.time()
-    balance = {"gbp": limit_gbp}
+    balance = {asset: 0.0 for asset in assets}
+    balance[principal_asset] = limit_gbp
 
     yield balance            # ---------- user code runs here ----------
 
-    delta = balance["gbp"]         # should be back at 0
-    if delta != 0 or time.time() - start > timeout_s:
+    elapsed = time.time() - start
+    if elapsed > timeout_s:
         raise RevertableLoanError(
-            f"Flash-loan NOT repaid: {delta:+.2f} GBP after {timeout_s}s"
+            f"Flash-loan window exceeded: {elapsed:.2f}s > {timeout_s}s"
         )
 
+    offenders = [asset for asset, value in balance.items() if abs(value) > 1e-9]
+    if offenders:
+        raise RevertableLoanError(
+            f"Flash-loan NOT repaid on assets: {', '.join(offenders)}"
+        )

--- a/app/loan_web3.py
+++ b/app/loan_web3.py
@@ -1,19 +1,14 @@
 # app/loan_web3.py
 
 import os
+from typing import Optional, Tuple, Dict
+
 from web3 import Web3, HTTPProvider
+from web3.middleware import geth_poa_middleware
 
 # ABI snippet for FlashLoan.flashLoan
 FLASH_LOAN_ABI = [
-    # constructor(uint256 _feeBps)
-    {
-        "inputs": [
-            {"internalType": "uint256", "name": "_feeBps", "type": "uint256"}
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor",
-    },
-    # flashLoan(address receiver, uint256 amount)
+    {"inputs": [{"internalType": "uint256", "name": "_feeBps", "type": "uint256"}], "stateMutability": "nonpayable", "type": "constructor"},
     {
         "inputs": [
             {"internalType": "address", "name": "receiver", "type": "address"},
@@ -26,36 +21,106 @@ FLASH_LOAN_ABI = [
     },
 ]
 
+RECEIVER_ABI = [
+    {
+        "anonymous": False,
+        "inputs": [
+            {"indexed": False, "internalType": "uint256", "name": "amount", "type": "uint256"},
+            {"indexed": False, "internalType": "uint256", "name": "fee", "type": "uint256"},
+        ],
+        "name": "Executed",
+        "type": "event",
+    }
+]
+
+NETWORK_RPC_ENV = {
+    "hardhat": "HARDHAT_RPC",
+    "anvil": "ANVIL_RPC_URL",
+    "sepolia": "SEPOLIA_RPC_URL",
+    "mainnet": "MAINNET_RPC_URL",
+}
+
 
 class Web3FlashLoan:
-    def __init__(self, lender_address: str, private_key: str, rpc_url: str):
-        # 1) connect to the node
-        self.w3 = Web3(HTTPProvider(rpc_url))
+    def __init__(
+        self,
+        lender_address: str,
+        private_key: str,
+        *,
+        network: str = "hardhat",
+        rpc_url: Optional[str] = None,
+    ):
+        # 1) resolve RPC endpoint
+        self.network = network
+        env_var = NETWORK_RPC_ENV.get(network)
+        endpoint = rpc_url or os.getenv("FLASH_LOAN_RPC_URL")
+        if not endpoint and env_var:
+            endpoint = os.getenv(env_var)
+        if not endpoint:
+            raise ValueError(f"Missing RPC URL for network '{network}'")
+
+        self.w3 = Web3(HTTPProvider(endpoint))
+        if network in {"sepolia", "mainnet"}:
+            self.w3.middleware_onion.inject(geth_poa_middleware, layer=0)
         if not self.w3.is_connected():
-            raise ConnectionError(f"Unable to connect to RPC at {rpc_url}")
+            raise ConnectionError(f"Unable to connect to RPC at {endpoint}")
 
-        # 2) read the actual chain ID (Hardhat defaults to 31337)
         self.chain_id = self.w3.eth.chain_id
-
-        # 3) set up our account and contract
         self.account = self.w3.eth.account.from_key(private_key)
-        self.lender  = self.w3.eth.contract(address=lender_address, abi=FLASH_LOAN_ABI)
+        self.lender = self.w3.eth.contract(address=lender_address, abi=FLASH_LOAN_ABI)
+        self._nonce = self.w3.eth.get_transaction_count(self.account.address)
 
-    def flash_loan(self, receiver_address: str, amount_wei: int):
-        # build the transaction
-        tx = self.lender.functions.flashLoan(receiver_address, amount_wei).build_transaction({
-            "from":     self.account.address,
-            "nonce":    self.w3.eth.get_transaction_count(self.account.address),
-            "gas":      300_000,
-            "gasPrice": self.w3.eth.gas_price,
-            "chainId":  self.chain_id,
-        })
+    def _next_nonce(self) -> int:
+        nonce = self._nonce
+        self._nonce += 1
+        return nonce
 
-        # sign & send
-        signed  = self.account.sign_transaction(tx)
-        raw     = signed.raw_transaction
-        tx_hash = self.w3.eth.send_raw_transaction(raw)
+    def flash_loan(
+        self,
+        *,
+        receiver_address: str,
+        amount_wei: int,
+        expected_fee_bps: float = 0.0,
+    ) -> Tuple[Dict[str, int], Dict[str, int]]:
+        """Execute a flash-loan and decode the receiver's Executed event."""
+        tx = self.lender.functions.flashLoan(receiver_address, amount_wei).build_transaction(
+            {
+                "from": self.account.address,
+                "nonce": self._next_nonce(),
+                "gas": 400_000,
+                "gasPrice": self.w3.eth.gas_price,
+                "chainId": self.chain_id,
+            }
+        )
 
-        # wait for it to be mined
+        signed = self.account.sign_transaction(tx)
+        tx_hash = self.w3.eth.send_raw_transaction(signed.raw_transaction)
         receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
-        return receipt
+        if receipt.status != 1:
+            raise RuntimeError("Flash-loan transaction reverted")
+
+        receiver = self.w3.eth.contract(address=receiver_address, abi=RECEIVER_ABI)
+        logs = receiver.events.Executed().process_receipt(receipt)
+        if not logs:
+            raise RuntimeError("Receiver did not emit Executed event")
+        event_args = logs[-1]["args"]
+        amount_logged = int(event_args["amount"])
+        fee_logged = int(event_args["fee"])
+
+        if amount_logged != int(amount_wei):
+            raise RuntimeError(
+                f"Receiver amount mismatch (expected {amount_wei}, got {amount_logged})"
+            )
+        expected_fee = int((amount_wei * expected_fee_bps) / 10_000)
+        if expected_fee and fee_logged != expected_fee:
+            raise RuntimeError(
+                f"Receiver fee mismatch (expected {expected_fee}, got {fee_logged})"
+            )
+
+        decoded = {"amount": amount_logged, "fee": fee_logged}
+        meta = {
+            "status": receipt.status,
+            "blockNumber": receipt.blockNumber,
+            "transactionHash": receipt.transactionHash.hex(),
+        }
+        return meta, decoded

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -7,6 +7,7 @@ loops forever once every second.
 import os
 from datetime import datetime, date
 from time import sleep
+from uuid import uuid4
 
 from app.logger import logger
 from app.metrics import METRICS
@@ -16,6 +17,8 @@ from app.storage import (
     get_open_orders,
     save_order,
     update_order,
+    record_loan_drawdown,
+    record_loan_repayment,
     Order,
 )
 from app.config import settings
@@ -58,6 +61,11 @@ def _today() -> date:
 # Globals to track daily PnL
 _current_day: date = _today()
 _daily_loss:   float = 0.0
+
+
+def _new_loan_reference() -> str:
+    stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    return f"loan-{stamp}-{uuid4().hex[:8]}"
 
 def _settle_open_orders(pl):
     for o in get_open_orders():
@@ -127,27 +135,74 @@ def run_cycle() -> bool:
         METRICS.trades_blocked.inc()
         return False
 
+    loan_amount = settings.loan_size_gbp
+    fee_gbp = loan_amount * settings.loan_fee_bps / 10_000
+    repayment_total = loan_amount + fee_gbp
+    repayment_assets = list(settings.loan_repayment_assets or [settings.loan_principal_asset])
+
     # ── On‐chain flash‐loan branch ─────────────────────────────────────────────
     if os.getenv("USE_WEB3_LOAN") == "1":
         if not settings.receiver_address:
             raise RuntimeError(
                 "USE_WEB3_LOAN=1 but FLASH_LOAN_RECEIVER is not set"
             )
+        if not settings.flash_loan_contract:
+            raise RuntimeError(
+                "USE_WEB3_LOAN=1 but FLASH_LOAN_CONTRACT is not set"
+            )
+        private_key = os.getenv("LENDER_KEY")
+        if not private_key:
+            raise RuntimeError("USE_WEB3_LOAN=1 but LENDER_KEY is missing")
 
+        rpc_url = settings.rpc_url_for_network()
         loan = FlashLoanAdapter(
             lender_address=settings.flash_loan_contract,
-            private_key=os.getenv("LENDER_KEY"),
+            private_key=private_key,
+            network=settings.flash_loan_network,
+            rpc_url=rpc_url,
         )
-        receipt = loan.flash_loan(
+        reference = _new_loan_reference()
+        record_loan_drawdown(
+            asset=settings.loan_principal_asset,
+            amount=loan_amount,
+            fee_bps=settings.loan_fee_bps,
+            reference=reference,
+            metadata={"mode": "web3", "network": settings.flash_loan_network},
+        )
+        amount_wei = int(loan_amount * (10 ** settings.loan_asset_decimals))
+        meta, decoded_event = loan.flash_loan(
             receiver_address=settings.receiver_address,
-            amount_wei=100_000 * 10**18,
+            amount_wei=amount_wei,
+            expected_fee_bps=settings.loan_fee_bps,
+        )
+        record_loan_repayment(
+            asset=settings.loan_principal_asset,
+            amount=repayment_total,
+            fee_bps=settings.loan_fee_bps,
+            reference=reference,
+            tx_hash=meta["transactionHash"],
+            chain_id=loan.chain_id,
+            metadata={"event": decoded_event, **meta},
         )
         return True
 
     # ── Mock flash‐loan branch ─────────────────────────────────────────────────
     else:
-        with FlashLoanAdapter(limit_gbp=100_000) as wallet:
+        with FlashLoanAdapter(
+            limit_gbp=loan_amount,
+            principal_asset=settings.loan_principal_asset,
+            repayment_assets=repayment_assets,
+        ) as wallet:
             try:
+                reference = _new_loan_reference()
+                record_loan_drawdown(
+                    asset=settings.loan_principal_asset,
+                    amount=loan_amount,
+                    fee_bps=settings.loan_fee_bps,
+                    reference=reference,
+                    metadata={"mode": "sim"},
+                )
+                cash_balance = loan_amount
                 # Leg A – buy power at current spot price cap
                 try:
                     fill_a = pl.buy(qty, max_price=spot)
@@ -167,15 +222,23 @@ def run_cycle() -> bool:
                     status="PENDING",
                 ))
 
-                # Leg A funds returned
-                wallet["gbp"] += fill_a.qty_mwh * fill_a.price
+                cash_balance -= fill_a.qty_mwh * fill_a.price
 
                 # Leg B – short Baseload future
                 fill_b = ice.sell(qty)
-                wallet["gbp"] += fill_b.qty_mwh * fill_b.price
+                cash_balance += fill_b.qty_mwh * fill_b.price
+
+                if cash_balance < repayment_total:
+                    logger.error(
+                        "Insufficient GBP to settle flash-loan: cash=%.2f required=%.2f",
+                        cash_balance,
+                        repayment_total,
+                    )
+                    METRICS.trades_blocked.inc()
+                    return False
 
                 # Record PnL
-                profit = wallet["gbp"] - 100_000
+                profit = cash_balance - repayment_total
                 if profit >= 0:
                     METRICS.profit_positive.inc(profit)
                 else:
@@ -185,6 +248,14 @@ def run_cycle() -> bool:
                 if profit < 0:
                     _daily_loss += -profit
                     METRICS.daily_loss.set(_daily_loss)
+
+                record_loan_repayment(
+                    asset=settings.loan_principal_asset,
+                    amount=repayment_total,
+                    fee_bps=settings.loan_fee_bps,
+                    reference=reference,
+                    metadata={"mode": "sim", "profit": profit},
+                )
 
                 save_trade(
                     qty_mwh=qty,
@@ -197,7 +268,8 @@ def run_cycle() -> bool:
 
             finally:
                 # ALWAYS repay principal before context exits
-                wallet["gbp"] = 0
+                for asset in set(repayment_assets + [settings.loan_principal_asset]):
+                    wallet[asset] = 0.0
 
 # ---------------------------------------------------------------------------
 # Simple CLI loop

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -177,12 +177,17 @@ def run_cycle() -> bool:
         )
         record_loan_repayment(
             asset=settings.loan_principal_asset,
-            amount=repayment_total,
+            amount=loan_amount,
             fee_bps=settings.loan_fee_bps,
             reference=reference,
             tx_hash=meta["transactionHash"],
             chain_id=loan.chain_id,
-            metadata={"event": decoded_event, **meta},
+            metadata={
+                "event": decoded_event,
+                "fee_paid": fee_gbp,
+                "repayment_total": repayment_total,
+                **meta,
+            },
         )
         return True
 
@@ -251,10 +256,15 @@ def run_cycle() -> bool:
 
                 record_loan_repayment(
                     asset=settings.loan_principal_asset,
-                    amount=repayment_total,
+                    amount=loan_amount,
                     fee_bps=settings.loan_fee_bps,
                     reference=reference,
-                    metadata={"mode": "sim", "profit": profit},
+                    metadata={
+                        "mode": "sim",
+                        "profit": profit,
+                        "fee_paid": fee_gbp,
+                        "repayment_total": repayment_total,
+                    },
                 )
 
                 save_trade(

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,5 +1,6 @@
 # app/storage.py
 
+import json
 import sqlite3
 from pathlib import Path
 from datetime import datetime
@@ -9,34 +10,102 @@ from typing import List, Optional, NamedTuple, Dict, Any
 # ─── Database setup ──────────────────────────────────────────────────────────
 
 _DB_PATH = Path("data") / "flash_green.db"
-_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-_conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
-_conn.row_factory = sqlite3.Row
+_conn: Optional[sqlite3.Connection] = None
 
-# Create tables if they don't exist
-with _conn:
-    _conn.execute("""
-    CREATE TABLE IF NOT EXISTS trades (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        qty_mwh    REAL,
-        spot_price REAL,
-        fut_price  REAL,
-        profit     REAL,
-        timestamp  TEXT
-    )""")
-    _conn.execute("""
-    CREATE TABLE IF NOT EXISTS orders (
-        id            TEXT PRIMARY KEY,
-        symbol        TEXT,
-        side          TEXT,
-        qty_requested REAL,
-        qty_filled    REAL,
-        avg_price     REAL,
-        status        TEXT,
-        timestamp     TEXT
-    )""")
+
+def init_db(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    """Initialise (or reinitialise) the sqlite database."""
+    global _DB_PATH, _conn
+    if db_path is not None:
+        _DB_PATH = Path(db_path)
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if _conn is not None:
+        _conn.close()
+    _conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+    _conn.row_factory = sqlite3.Row
+    _create_tables()
+    return _conn
+
+
+def _get_conn() -> sqlite3.Connection:
+    global _conn
+    if _conn is None:
+        init_db(_DB_PATH)
+    assert _conn is not None
+    return _conn
+
+
+def _create_tables() -> None:
+    conn = _get_conn()
+    with conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                qty_mwh    REAL,
+                spot_price REAL,
+                fut_price  REAL,
+                profit     REAL,
+                timestamp  TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS orders (
+                id            TEXT PRIMARY KEY,
+                symbol        TEXT,
+                side          TEXT,
+                qty_requested REAL,
+                qty_filled    REAL,
+                avg_price     REAL,
+                status        TEXT,
+                timestamp     TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS loan_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                reference   TEXT,
+                event_type  TEXT,
+                asset       TEXT,
+                amount      REAL,
+                fee_bps     REAL,
+                tx_hash     TEXT,
+                chain_id    INTEGER,
+                metadata    TEXT,
+                timestamp   TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS loan_balances (
+                asset       TEXT PRIMARY KEY,
+                outstanding REAL NOT NULL DEFAULT 0,
+                updated_at  TEXT NOT NULL
+            )
+            """
+        )
+
+
+# ensure DB initialised on import
+init_db()
+
 
 # ─── Models ──────────────────────────────────────────────────────────────────
+
+@dataclass
+class Trade:
+    id: int
+    qty_mwh: float
+    spot_price: float
+    fut_price: float
+    profit: float
+    timestamp: str
+
 
 class Order(NamedTuple):
     id: str
@@ -48,28 +117,76 @@ class Order(NamedTuple):
     status: str
     timestamp: str
 
+
+class LoanEvent(NamedTuple):
+    id: int
+    reference: Optional[str]
+    event_type: str
+    asset: str
+    amount: float
+    fee_bps: float
+    tx_hash: Optional[str]
+    chain_id: Optional[int]
+    metadata: Optional[Dict[str, Any]]
+    timestamp: str
+
+
+class LoanBalance(NamedTuple):
+    asset: str
+    outstanding: float
+    updated_at: str
+
+
 # ─── Trade persistence ───────────────────────────────────────────────────────
 
-def save_trade(qty_mwh: float, spot_price: float, fut_price: float, profit: float) -> None:
+
+def save_trade(qty_mwh: float, spot_price: float, fut_price: float, profit: float) -> Trade:
     """Persist a completed trade (used by your PoC)."""
     ts = datetime.utcnow().isoformat()
-    with _conn:
-        _conn.execute(
-            "INSERT INTO trades (qty_mwh, spot_price, fut_price, profit, timestamp) VALUES (?, ?, ?, ?, ?)",
+    conn = _get_conn()
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO trades (qty_mwh, spot_price, fut_price, profit, timestamp)
+            VALUES (?, ?, ?, ?, ?)
+            """,
             (qty_mwh, spot_price, fut_price, profit, ts),
         )
+        trade_id = cur.lastrowid
+    return Trade(
+        id=trade_id,
+        qty_mwh=qty_mwh,
+        spot_price=spot_price,
+        fut_price=fut_price,
+        profit=profit,
+        timestamp=ts,
+    )
 
-def get_trades() -> List[Dict[str, Any]]:
-    """Fetch all past trades for your PnL API."""
-    cur = _conn.execute("SELECT qty_mwh, spot_price, fut_price, profit, timestamp FROM trades ORDER BY id")
-    return [dict(row) for row in cur.fetchall()]
+
+def get_trades(limit: int = 100) -> List[Trade]:
+    """Fetch past trades for the public API."""
+    conn = _get_conn()
+    cur = conn.execute(
+        """
+        SELECT id, qty_mwh, spot_price, fut_price, profit, timestamp
+          FROM trades
+         ORDER BY id DESC
+         LIMIT ?
+        """,
+        (limit,),
+    )
+    rows = cur.fetchall()
+    return [Trade(**dict(row)) for row in rows]
+
 
 # ─── Order‐tracking / idempotency ────────────────────────────────────────────
 
+
 def save_order(order: Order) -> None:
-    """Insert or replace an in‐flight ICE order."""
-    with _conn:
-        _conn.execute(
+    """Insert or replace an in-flight ICE order."""
+    conn = _get_conn()
+    with conn:
+        conn.execute(
             """
             INSERT OR REPLACE INTO orders
               (id, symbol, side, qty_requested, qty_filled, avg_price, status, timestamp)
@@ -87,9 +204,11 @@ def save_order(order: Order) -> None:
             ),
         )
 
+
 def get_open_orders() -> List[Order]:
     """Return all orders not yet FILLED/CANCELLED/REJECTED."""
-    cur = _conn.execute(
+    conn = _get_conn()
+    cur = conn.execute(
         """
         SELECT id, symbol, side, qty_requested, qty_filled, avg_price, status, timestamp
           FROM orders
@@ -98,10 +217,145 @@ def get_open_orders() -> List[Order]:
     )
     return [Order(**row) for row in cur.fetchall()]
 
+
 def update_order(order_id: str, filled: float, avg_price: float, status: str) -> None:
     """Update status/filled/price for an existing order."""
-    with _conn:
-        _conn.execute(
+    conn = _get_conn()
+    with conn:
+        conn.execute(
             "UPDATE orders SET qty_filled=?, avg_price=?, status=? WHERE id=?",
             (filled, avg_price, status, order_id),
         )
+
+
+# ─── Loan tracking ───────────────────────────────────────────────────────────
+
+
+def _persist_loan_event(
+    *,
+    event_type: str,
+    asset: str,
+    amount: float,
+    fee_bps: float,
+    reference: Optional[str],
+    tx_hash: Optional[str],
+    chain_id: Optional[int],
+    metadata: Optional[Dict[str, Any]],
+    delta_sign: int,
+) -> LoanEvent:
+    ts = datetime.utcnow().isoformat()
+    payload = json.dumps(metadata) if metadata else None
+    conn = _get_conn()
+    with conn:
+        cur = conn.execute(
+            """
+            INSERT INTO loan_events (reference, event_type, asset, amount, fee_bps, tx_hash, chain_id, metadata, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (reference, event_type, asset, amount, fee_bps, tx_hash, chain_id, payload, ts),
+        )
+        conn.execute(
+            """
+            INSERT INTO loan_balances (asset, outstanding, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(asset) DO UPDATE SET
+                outstanding = loan_balances.outstanding + excluded.outstanding,
+                updated_at = excluded.updated_at
+            """,
+            (asset, delta_sign * amount, ts),
+        )
+        event_id = cur.lastrowid
+    return LoanEvent(
+        id=event_id,
+        reference=reference,
+        event_type=event_type,
+        asset=asset,
+        amount=amount,
+        fee_bps=fee_bps,
+        tx_hash=tx_hash,
+        chain_id=chain_id,
+        metadata=metadata,
+        timestamp=ts,
+    )
+
+
+def record_loan_drawdown(
+    *,
+    asset: str,
+    amount: float,
+    fee_bps: float = 0.0,
+    reference: Optional[str] = None,
+    tx_hash: Optional[str] = None,
+    chain_id: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> LoanEvent:
+    """Record a drawdown event."""
+    return _persist_loan_event(
+        event_type="DRAW",
+        asset=asset,
+        amount=amount,
+        fee_bps=fee_bps,
+        reference=reference,
+        tx_hash=tx_hash,
+        chain_id=chain_id,
+        metadata=metadata,
+        delta_sign=+1,
+    )
+
+
+def record_loan_repayment(
+    *,
+    asset: str,
+    amount: float,
+    fee_bps: float = 0.0,
+    reference: Optional[str] = None,
+    tx_hash: Optional[str] = None,
+    chain_id: Optional[int] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> LoanEvent:
+    """Record a repayment event."""
+    return _persist_loan_event(
+        event_type="REPAY",
+        asset=asset,
+        amount=amount,
+        fee_bps=fee_bps,
+        reference=reference,
+        tx_hash=tx_hash,
+        chain_id=chain_id,
+        metadata=metadata,
+        delta_sign=-1,
+    )
+
+
+def get_loan_events(limit: int = 100) -> List[LoanEvent]:
+    conn = _get_conn()
+    cur = conn.execute(
+        """
+        SELECT id, reference, event_type, asset, amount, fee_bps, tx_hash, chain_id, metadata, timestamp
+          FROM loan_events
+         ORDER BY id DESC
+         LIMIT ?
+        """,
+        (limit,),
+    )
+    rows = cur.fetchall()
+    events: List[LoanEvent] = []
+    for row in rows:
+        meta = json.loads(row["metadata"]) if row["metadata"] else None
+        payload = dict(row)
+        payload["metadata"] = meta
+        events.append(LoanEvent(**payload))
+    return events
+
+
+def get_loan_balances() -> List[LoanBalance]:
+    conn = _get_conn()
+    cur = conn.execute(
+        """
+        SELECT asset, outstanding, updated_at
+          FROM loan_balances
+         ORDER BY asset
+        """
+    )
+    return [LoanBalance(**row) for row in cur.fetchall()]
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,25 @@
 from fastapi.testclient import TestClient
-from app.web import api, get_trades
+from app.web import api
 
 client = TestClient(api)
 
+
 def test_trades_endpoint_empty(monkeypatch):
-    monkeypatch.setattr("app.web.get_trades", lambda limit: [])
+    monkeypatch.setattr("app.web.get_trades", lambda limit=100: [])
     resp = client.get("/trades")
     assert resp.status_code == 200
     assert resp.json() == []
 
 
+def test_loan_events_endpoint_empty(monkeypatch):
+    monkeypatch.setattr("app.web.get_loan_events", lambda limit=100: [])
+    resp = client.get("/loans/events")
+    assert resp.status_code == 200
+    assert resp.json() == []
 
+
+def test_loan_balances_endpoint_empty(monkeypatch):
+    monkeypatch.setattr("app.web.get_loan_balances", lambda: [])
+    resp = client.get("/loans/balances")
+    assert resp.status_code == 200
+    assert resp.json() == []

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,21 +1,34 @@
-import os
-import sqlite3
-from pathlib import Path
-from app.storage import init_db, save_trade, get_trades, _DB_PATH
+from app.storage import (
+    init_db,
+    save_trade,
+    get_trades,
+    record_loan_drawdown,
+    record_loan_repayment,
+    get_loan_events,
+    get_loan_balances,
+)
 
-def test_save_and_load(tmp_path, monkeypatch):
-    # isolate to a temp DB
-    test_db = tmp_path / "test.db"
-    monkeypatch.setattr("app.storage._DB_PATH", test_db)
 
-    # start fresh
-    if test_db.exists(): test_db.unlink()
-    init_db()
+def test_save_and_load(tmp_path):
+    db = tmp_path / "test.db"
+    init_db(db)
 
-    t = save_trade(qty_mwh=1.5, spot_price=-5.0, fut_price=65.0, profit=100.0)
-    assert t.id == 1
+    trade = save_trade(qty_mwh=1.5, spot_price=-5.0, fut_price=65.0, profit=100.0)
     recs = get_trades(limit=10)
     assert len(recs) == 1
     assert recs[0].profit == 100.0
+    assert trade.id == recs[0].id
 
 
+def test_loan_events_and_balances(tmp_path):
+    db = tmp_path / "loan.db"
+    init_db(db)
+
+    record_loan_drawdown(asset="gbp", amount=50.0, reference="ref-1")
+    record_loan_repayment(asset="gbp", amount=50.0, reference="ref-1")
+
+    events = get_loan_events(limit=10)
+    assert len(events) == 2
+    balances = get_loan_balances()
+    assert balances[0].asset == "gbp"
+    assert balances[0].outstanding == 0


### PR DESCRIPTION
## Summary
- add loan sizing, fee, repayment asset settings and wire them through the orchestrator plus the Web3 adapter so flash-loan flows match on-chain settlement
- persist drawdowns/repayments in sqlite and expose the audit log plus balance views over FastAPI for ops visibility
- extend the mocked/Web3 loan helpers and unit tests to cover the new storage primitives and API handlers

## Testing
- `PYENV_VERSION=3.12.12 pytest` *(fails: pytest tries to collect third-party Google Cloud SDK tests that require missing dependencies such as `google_reauth`, `pytest_asyncio`, and `mock`)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69181b39a0608327a0d7f04d005602b6)