### PR TITLE
Ensure Web3 flash loan adapter has RPC configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Sample configuration for flash-green-poc
+# Copy to .env and adjust for your environment
+
+# Toggle flash-loan adapter
+USE_WEB3_LOAN=0
+
+# Web3 / Hardhat settings
+HARDHAT_RPC=http://127.0.0.1:8545
+FLASH_LOAN_CONTRACT=0xYourFlashLoanContract
+FLASH_LOAN_RECEIVER=0xYourReceiverContract
+LENDER_KEY=0xyourPrivateKey

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # flash-green-poc
+
+## Configuration
+
+Environment variables can be stored in a local `.env` file (loaded automatically).
+When running the on-chain flash-loan path (`USE_WEB3_LOAN=1`) ensure the RPC
+endpoint is supplied via `HARDHAT_RPC`. For example:
+
+```
+HARDHAT_RPC=http://127.0.0.1:8545
+FLASH_LOAN_CONTRACT=0xYourFlashLoanContract
+FLASH_LOAN_RECEIVER=0xYourReceiverContract
+LENDER_KEY=0xyourPrivateKey
+USE_WEB3_LOAN=1
+```
+
+Point `HARDHAT_RPC` at whichever Hardhat, Anvil, or mainnet/Goerli JSON-RPC
+endpoint you plan to use.

--- a/app/config.py
+++ b/app/config.py
@@ -73,7 +73,11 @@ class Settings(BaseSettings):
     bmrs_api_key: Optional[str] = None
     ice_user:     Optional[str] = None
     ice_pass:     Optional[str] = None
-    hardhat_rpc:  Optional[AnyUrl] = Field("http://127.0.0.1:8545", description="EVM RPC")
+    hardhat_rpc:  Optional[AnyUrl] = Field(
+        "http://127.0.0.1:8545",
+        env="HARDHAT_RPC",
+        description="HTTP RPC endpoint for Hardhat or another EVM node",
+    )
 
     # ----------------------------------------------------------------------
     # On-chain flash-loan contract (Hardhat/EVM)

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -134,9 +134,22 @@ def run_cycle() -> bool:
                 "USE_WEB3_LOAN=1 but FLASH_LOAN_RECEIVER is not set"
             )
 
+        lender_key = os.getenv("LENDER_KEY")
+        if not lender_key:
+            raise RuntimeError(
+                "USE_WEB3_LOAN=1 but LENDER_KEY is not set"
+            )
+
+        rpc_url = settings.hardhat_rpc
+        if not rpc_url:
+            raise RuntimeError(
+                "USE_WEB3_LOAN=1 but HARDHAT_RPC is not configured"
+            )
+
         loan = FlashLoanAdapter(
             lender_address=settings.flash_loan_contract,
-            private_key=os.getenv("LENDER_KEY"),
+            private_key=lender_key,
+            rpc_url=rpc_url,
         )
         receipt = loan.flash_loan(
             receiver_address=settings.receiver_address,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,5 +1,9 @@
 # tests/test_orchestrator.py
+import importlib
+import sys
+
 import pytest
+
 from app.orchestrator import run_cycle
 
 def test_pnl_positive():
@@ -11,3 +15,49 @@ def test_pnl_positive():
 
     # scrape prometheus or patch METRICS to assert profit > 0
 
+
+def test_web3_adapter_receives_rpc(monkeypatch):
+    monkeypatch.setenv("USE_WEB3_LOAN", "1")
+    monkeypatch.setenv("FLASH_LOAN_RECEIVER", "0xReceiver")
+    monkeypatch.setenv("RECEIVER_ADDRESS", "0xReceiver")
+    monkeypatch.setenv("FLASH_LOAN_CONTRACT", "0xLender")
+    monkeypatch.setenv("LENDER_KEY", "0x1234")
+    monkeypatch.setenv("HARDHAT_RPC", "http://example-rpc:8545")
+
+    # ensure orchestrator reloads with the updated env
+    sys.modules.pop("app.orchestrator", None)
+    sys.modules.pop("app.config", None)
+    config = importlib.import_module("app.config")
+    config.get_settings.cache_clear()
+    config.settings = config.get_settings()
+    orchestrator = importlib.import_module("app.orchestrator")
+
+    class DummyFeed:
+        def advance(self):
+            pass
+
+        def quote(self):
+            return 10.0
+
+    orchestrator.pl = DummyFeed()
+    orchestrator.ice = DummyFeed()
+
+    monkeypatch.setattr(orchestrator, "should_trade", lambda *_: (True, 1.0, 1.0))
+
+    captured = {}
+
+    class DummyLoan:
+        def __init__(self, lender_address, private_key, rpc_url):
+            captured["params"] = {
+                "lender_address": lender_address,
+                "private_key": private_key,
+                "rpc_url": rpc_url,
+            }
+
+        def flash_loan(self, **_):
+            return {"status": "ok"}
+
+    monkeypatch.setattr(orchestrator, "FlashLoanAdapter", DummyLoan)
+
+    assert orchestrator.run_cycle() is True
+    assert str(captured["params"]["rpc_url"]) == str(orchestrator.settings.hardhat_rpc)


### PR DESCRIPTION
## Summary
- ensure the Web3 flash-loan path validates its required configuration and passes the RPC URL to the adapter
- document the new HARDHAT_RPC setting in app/config.py, README, and a `.env` sample file for operators
- add a regression test that forces USE_WEB3_LOAN=1 and verifies the adapter constructor receives the RPC URL

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_orchestrator.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691822c371308327ba2e169d60d5c065)