### PR TITLE
Enforce daily loss cap in orchestrator

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -103,6 +103,15 @@ def run_cycle() -> bool:
         METRICS.trades_blocked.inc()
         return False
 
+    if _daily_loss >= settings.max_daily_loss_gbp:
+        METRICS.trades_blocked.inc()
+        logger.warning(
+            "Daily loss cap reached (£%.2f/£%.2f); skipping trades",
+            _daily_loss,
+            settings.max_daily_loss_gbp,
+        )
+        return False
+
     POWER.advance()
     ice.advance()
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -35,3 +35,46 @@ def test_trading_enabled_switch():
     settings.trading_enabled = False
     assert run_cycle() is False
     settings.trading_enabled = True
+    settings.max_notional_per_trade = 1_000_000.0
+
+
+def test_daily_loss_cap(monkeypatch):
+    settings.trading_enabled = True
+    settings.max_daily_loss_gbp = 100.0
+
+    orch._current_day = orch._today()
+    orch._daily_loss = 50.0
+
+    blocked_start = orch.METRICS.trades_blocked._value.get()
+
+    def fake_should_trade(*_):
+        return True, 1.0, 0.0
+
+    class Fill:
+        def __init__(self, price: float):
+            self.order_id = "1"
+            self.qty_mwh = 1.0
+            self.price = price
+
+    monkeypatch.setattr("app.orchestrator.should_trade", fake_should_trade)
+    monkeypatch.setattr("app.orchestrator.POWER.quote", lambda: 10_000.0)
+    monkeypatch.setattr("app.orchestrator.ice.quote", lambda: 9_999.0)
+    monkeypatch.setattr("app.orchestrator.POWER.buy", lambda *_, **__: Fill(-20.0))
+    monkeypatch.setattr("app.orchestrator.ice.sell", lambda *_, **__: Fill(-30.0))
+    monkeypatch.setattr("app.orchestrator.save_order", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("app.orchestrator.save_trade", lambda *_args, **_kwargs: None)
+
+    assert run_cycle() is True
+    assert orch._daily_loss == 100.0
+
+    call_count = {"calls": 0}
+
+    def should_not_run(*_):
+        call_count["calls"] += 1
+        return True, 1.0, 0.0
+
+    monkeypatch.setattr("app.orchestrator.should_trade", should_not_run)
+
+    assert run_cycle() is False
+    assert call_count["calls"] == 0
+    assert orch.METRICS.trades_blocked._value.get() == blocked_start + 1


### PR DESCRIPTION
## Summary
- add a guard that blocks new trades when the configured daily loss cap is reached and logs the event
- extend risk tests to cover daily loss accumulation and ensure trades halt once the threshold is hit

## Testing
- PYTHONPATH=. pytest tests/test_risk.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b42a7c2dc8327be82f0c21fe8193d)