### PR TITLE
Refactor storage connections to use per-request SQLite handles

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -1,45 +1,93 @@
 # app/storage.py
 
+from contextlib import contextmanager
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple
+from typing import Any, Dict, List, NamedTuple, Iterator
 
 # ─── Database setup ──────────────────────────────────────────────────────────
 
 _DB_PATH = Path("data") / "flash_green.db"
 _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-_conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
-_conn.row_factory = sqlite3.Row
 
-# Create tables if they don't exist
-with _conn:
-    _conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS trades (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            qty_mwh    REAL,
-            spot_price REAL,
-            fut_price  REAL,
-            profit     REAL,
-            timestamp  TEXT
-        )
-        """
-    )
-    _conn.execute(
-        """
-        CREATE TABLE IF NOT EXISTS orders (
-            id            TEXT PRIMARY KEY,
-            symbol        TEXT,
-            side          TEXT,
-            qty_requested REAL,
-            qty_filled    REAL,
-            avg_price     REAL,
-            status        TEXT,
-            timestamp     TEXT
-        )
-        """
-    )
+
+def _configure_connection(conn: sqlite3.Connection) -> None:
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL;")
+    conn.execute("PRAGMA foreign_keys=ON;")
+
+
+def _create_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False, isolation_level=None)
+    _configure_connection(conn)
+    return conn
+
+
+@contextmanager
+def get_connection() -> Iterator[sqlite3.Connection]:
+    conn = _create_connection()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@contextmanager
+def transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
+    try:
+        conn.execute("BEGIN")
+        yield conn
+        conn.execute("COMMIT")
+    except Exception:
+        conn.execute("ROLLBACK")
+        raise
+
+
+def _ensure_conn(conn: sqlite3.Connection | None) -> tuple[sqlite3.Connection, bool]:
+    if conn is not None:
+        return conn, False
+    return _create_connection(), True
+
+
+def _close_if_owned(conn: sqlite3.Connection, owns: bool) -> None:
+    if owns:
+        conn.close()
+
+
+def _init_schema() -> None:
+    with get_connection() as conn:
+        with transaction(conn):
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trades (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    qty_mwh    REAL,
+                    spot_price REAL,
+                    fut_price  REAL,
+                    profit     REAL,
+                    timestamp  TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS orders (
+                    id            TEXT PRIMARY KEY,
+                    symbol        TEXT,
+                    side          TEXT,
+                    qty_requested REAL,
+                    qty_filled    REAL,
+                    avg_price     REAL,
+                    status        TEXT,
+                    timestamp     TEXT
+                )
+                """
+            )
+
+
+_init_schema()
+
 
 # ─── Models ──────────────────────────────────────────────────────────────────
 
@@ -54,6 +102,7 @@ class Order(NamedTuple):
     status: str
     timestamp: str
 
+
 # ─── Trade persistence ───────────────────────────────────────────────────────
 
 
@@ -62,21 +111,26 @@ def save_trade(
     spot_price: float,
     fut_price: float,
     profit: float,
+    conn: sqlite3.Connection | None = None,
 ) -> None:
     """Persist a completed trade (used by your PoC)."""
     ts = datetime.utcnow().isoformat()
-    with _conn:
-        _conn.execute(
-            """
-            INSERT INTO trades
-                (qty_mwh, spot_price, fut_price, profit, timestamp)
-            VALUES (?, ?, ?, ?, ?)
-            """,
-            (qty_mwh, spot_price, fut_price, profit, ts),
-        )
+    connection, owns_conn = _ensure_conn(conn)
+    try:
+        with transaction(connection):
+            connection.execute(
+                """
+                INSERT INTO trades
+                    (qty_mwh, spot_price, fut_price, profit, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (qty_mwh, spot_price, fut_price, profit, ts),
+            )
+    finally:
+        _close_if_owned(connection, owns_conn)
 
 
-def get_trades(limit: int | None = None) -> List[Dict[str, Any]]:
+def get_trades(limit: int | None = None, conn: sqlite3.Connection | None = None) -> List[Dict[str, Any]]:
     """Fetch past trades for your PnL API ordered by recency."""
     sql = """
         SELECT id, qty_mwh, spot_price, fut_price, profit, timestamp
@@ -88,54 +142,67 @@ def get_trades(limit: int | None = None) -> List[Dict[str, Any]]:
         sql += " LIMIT ?"
         params = (limit,)
 
-    cur = _conn.execute(sql, params)
-    return [dict(row) for row in cur.fetchall()]
+    connection, owns_conn = _ensure_conn(conn)
+    try:
+        cur = connection.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+    finally:
+        _close_if_owned(connection, owns_conn)
+
 
 # ─── Order‐tracking / idempotency ────────────────────────────────────────────
 
 
-def save_order(order: Order) -> None:
+def save_order(order: Order, conn: sqlite3.Connection | None = None) -> None:
     """Insert or replace an in‐flight ICE order."""
-    with _conn:
-        _conn.execute(
-            """
-            INSERT OR REPLACE INTO orders (
-                id, symbol, side, qty_requested,
-                qty_filled, avg_price, status, timestamp
+    connection, owns_conn = _ensure_conn(conn)
+    try:
+        with transaction(connection):
+            connection.execute(
+                """
+                INSERT OR REPLACE INTO orders (
+                    id, symbol, side, qty_requested,
+                    qty_filled, avg_price, status, timestamp
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    order.id,
+                    order.symbol,
+                    order.side,
+                    order.qty_requested,
+                    order.qty_filled,
+                    order.avg_price,
+                    order.status,
+                    order.timestamp,
+                ),
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                order.id,
-                order.symbol,
-                order.side,
-                order.qty_requested,
-                order.qty_filled,
-                order.avg_price,
-                order.status,
-                order.timestamp,
-            ),
-        )
+    finally:
+        _close_if_owned(connection, owns_conn)
 
 
-def get_open_orders() -> List[Order]:
+def get_open_orders(conn: sqlite3.Connection | None = None) -> List[Order]:
     """Return all orders not yet FILLED/CANCELLED/REJECTED."""
-    cur = _conn.execute(
-        """
-        SELECT
-            id,
-            symbol,
-            side,
-            qty_requested,
-            qty_filled,
-            avg_price,
-            status,
-            timestamp
-          FROM orders
-         WHERE status NOT IN ('FILLED','CANCELLED','REJECTED')
-        """
-    )
-    return [Order(**row) for row in cur.fetchall()]
+    connection, owns_conn = _ensure_conn(conn)
+    try:
+        cur = connection.execute(
+            """
+            SELECT
+                id,
+                symbol,
+                side,
+                qty_requested,
+                qty_filled,
+                avg_price,
+                status,
+                timestamp
+              FROM orders
+             WHERE status NOT IN ('FILLED','CANCELLED','REJECTED')
+            """
+        )
+        return [Order(**row) for row in cur.fetchall()]
+    finally:
+        _close_if_owned(connection, owns_conn)
 
 
 def update_order(
@@ -143,14 +210,28 @@ def update_order(
     filled: float,
     avg_price: float,
     status: str,
+    conn: sqlite3.Connection | None = None,
 ) -> None:
     """Update status/filled/price for an existing order."""
-    with _conn:
-        _conn.execute(
-            """
-            UPDATE orders
-               SET qty_filled=?, avg_price=?, status=?
-             WHERE id=?
-            """,
-            (filled, avg_price, status, order_id),
-        )
+    connection, owns_conn = _ensure_conn(conn)
+    try:
+        with transaction(connection):
+            connection.execute(
+                """
+                UPDATE orders
+                   SET qty_filled=?, avg_price=?, status=?
+                 WHERE id=?
+                """,
+                (filled, avg_price, status, order_id),
+            )
+    finally:
+        _close_if_owned(connection, owns_conn)
+
+
+# ─── FastAPI dependency helper ───────────────────────────────────────────────
+
+
+def connection_dependency() -> Iterator[sqlite3.Connection]:
+    """Yield a configured connection for FastAPI dependencies."""
+    with get_connection() as conn:
+        yield conn


### PR DESCRIPTION
## Summary
- switch SQLite access to per-request connections with WAL mode and explicit transaction handling
- expose a FastAPI dependency to open/close connections and wire it into trades and orders endpoints
- update orchestration flow to reuse the connection helper for order settlement and persistence

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b622d2d38832784ca0181e2ea4198)