### PR TITLE
Honor injected storage connection

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -24,6 +24,9 @@ def _create_connection() -> sqlite3.Connection:
     return conn
 
 
+_conn: sqlite3.Connection | None = None
+
+
 @contextmanager
 def get_connection() -> Iterator[sqlite3.Connection]:
     conn = _create_connection()
@@ -45,6 +48,8 @@ def transaction(conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
 
 
 def _ensure_conn(conn: sqlite3.Connection | None) -> tuple[sqlite3.Connection, bool]:
+    if _conn is not None and conn is None:
+        return _conn, False
     if conn is not None:
         return conn, False
     return _create_connection(), True

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -32,13 +32,16 @@ def _temp_conn() -> sqlite3.Connection:
 
 
 def test_save_and_load(monkeypatch):
-    monkeypatch.setattr(storage, "_conn", _temp_conn())
+    test_conn = _temp_conn()
+    monkeypatch.setattr(storage, "_conn", test_conn)
     storage.save_trade(
         qty_mwh=1.5,
         spot_price=-5.0,
         fut_price=65.0,
         profit=100.0,
     )
+    profits = [row["profit"] for row in test_conn.execute("SELECT profit FROM trades").fetchall()]
+    assert profits == [100.0]
     trades = storage.get_trades()
     assert len(trades) == 1
     assert trades[0]["profit"] == 100.0
@@ -64,3 +67,39 @@ def test_get_trades_orders_by_recency(monkeypatch):
 
     assert [t["id"] for t in trades] == [3, 2]
     assert trades[0]["timestamp"] == "2024-01-02T00:00:00"
+
+
+def test_orders_use_shared_connection(monkeypatch):
+    conn = _temp_conn()
+    monkeypatch.setattr(storage, "_conn", conn)
+    open_order = storage.Order(
+        id="o-1",
+        symbol="SYM",
+        side="BUY",
+        qty_requested=10.0,
+        qty_filled=0.0,
+        avg_price=0.0,
+        status="NEW",
+        timestamp="2024-01-01T00:00:00",
+    )
+    filled_order = storage.Order(
+        id="o-2",
+        symbol="SYM",
+        side="SELL",
+        qty_requested=5.0,
+        qty_filled=5.0,
+        avg_price=25.0,
+        status="FILLED",
+        timestamp="2024-01-01T01:00:00",
+    )
+
+    storage.save_order(open_order)
+    storage.save_order(filled_order)
+
+    remaining = storage.get_open_orders()
+
+    assert remaining == [open_order]
+    assert [row["status"] for row in conn.execute("SELECT status FROM orders ORDER BY id")] == [
+        "NEW",
+        "FILLED",
+    ]


### PR DESCRIPTION
## Summary
- allow storage helpers to reuse an injected shared SQLite connection before creating new handles
- ensure trade and order queries honor the shared connection when present
- expand storage tests to cover shared connection usage with in-memory databases

## Testing
- PYTHONPATH=. poetry run pytest tests/test_storage.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba083b5908327913784787c12cedf)