### PR TITLE
Compute PnL totals from trades

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -11,8 +11,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from app.config import settings
 from app.logger import logger
-from app.metrics import METRICS
-from app.storage import connection_dependency, get_open_orders, get_trades
+from app.storage import connection_dependency, get_open_orders, get_pnl_totals, get_trades
 
 api = FastAPI(
     title="Flash-Green PoC",
@@ -83,11 +82,9 @@ async def prom():
 
 
 @api.get("/pnl", dependencies=[Depends(require_api_key)])
-async def pnl():
-    return {
-        "profit": METRICS.profit_positive._value.get(),
-        "loss": METRICS.profit_negative._value.get(),
-    }
+async def pnl(conn: sqlite3.Connection = Depends(connection_dependency)):
+    """Return aggregated profit/loss totals: net, positive, and negative."""
+    return get_pnl_totals(conn=conn)
 
 
 # ─── Data endpoints ──────────────────────────────────────────────────────────

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,3 +24,17 @@ def test_protected_endpoints_require_api_key_when_configured(monkeypatch):
 
     resp_valid = client.get("/pnl", headers={"X-API-Key": "secret-key"})
     assert resp_valid.status_code == 200
+
+
+def test_pnl_totals_are_returned(monkeypatch):
+    monkeypatch.setattr(settings, "api_key", None)
+    monkeypatch.setattr(
+        "app.web.get_pnl_totals",
+        lambda conn=None: {"net": 5.0, "positive": 8.0, "negative": 3.0},
+    )
+
+    client = _client()
+
+    resp = client.get("/pnl")
+    assert resp.status_code == 200
+    assert resp.json() == {"net": 5.0, "positive": 8.0, "negative": 3.0}


### PR DESCRIPTION
## Summary
- add a storage helper to aggregate net/positive/negative PnL from recorded trades
- update the /pnl endpoint to return those totals with a brief docstring
- cover the new behavior with an API test

## Testing
- poetry run pytest tests/test_api.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba488c8fc832794fe8133611e580c)