### PR TITLE
Add pluggable live futures exchange adapters

### DIFF
--- a/app/exchange_ice.py
+++ b/app/exchange_ice.py
@@ -1,4 +1,6 @@
 import time
+from typing import Tuple
+
 import requests
 
 from app.config import settings
@@ -8,7 +10,7 @@ from app.exchange import Fill
 DEFAULT_TIMEOUT = 10
 
 
-class ICEPowerExchange:
+class _ICERestBase:
     def __init__(self) -> None:
         self.base_url = settings.ice_api_url
         self.api_key = settings.ice_api_key
@@ -33,23 +35,54 @@ class ICEPowerExchange:
         )
 
     def advance(self) -> None:
+        # real REST endpoints are polled on each call
         return None
 
-    def quote(self) -> float:
+    def _fetch_orderbook(self) -> Tuple[float | None, float | None]:
         resp = self.session.get(
-            f"{self.base_url}/marketdata/{self.symbol}/price",
+            f"{self.base_url}/marketdata/{self.symbol}/orderbook",
             timeout=DEFAULT_TIMEOUT,
         )
         resp.raise_for_status()
-        return float(resp.json()["last_price"])
+        body = resp.json()
+        bids = body.get("bids") or []
+        asks = body.get("asks") or []
+
+        best_bid = float(bids[0]["price"]) if bids else None
+        best_ask = float(asks[0]["price"]) if asks else None
+        return best_bid, best_ask
+
+    def _fetch_order(self, order_id: str) -> dict:
+        resp = self.session.get(
+            f"{self.base_url}/orders/{order_id}", timeout=DEFAULT_TIMEOUT
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def cancel_order(self, order_id: str) -> None:
+        self.session.delete(
+            f"{self.base_url}/orders/{order_id}", timeout=DEFAULT_TIMEOUT
+        )
+
+
+class ICEPowerExchange(_ICERestBase):
+    def quote(self) -> float:
+        bid, ask = self._fetch_orderbook()
+        if ask is None:
+            raise RuntimeError("ICE orderbook has no asks; cannot price BUY leg")
+        return ask
 
     def buy(self, qty_mwh: float, max_price: float) -> Fill:
-        # 1) place limit buy
+        bid, ask = self._fetch_orderbook()
+        target_price = ask if ask is not None else max_price
+        if target_price > max_price:
+            raise RuntimeError("ICE ask above max_price")
+
         payload = {
             "symbol":   self.symbol,
             "side":     "BUY",
             "quantity": qty_mwh,
-            "price":    max_price,
+            "price":    target_price,
             "type":     "LIMIT",
         }
         resp = self.session.post(
@@ -59,7 +92,6 @@ class ICEPowerExchange:
         order = resp.json()
         order_id = order["id"]
 
-        # 2) poll until filled or timeout
         deadline = time.time() + settings.order_timeout_secs
         filled: float = 0.0
         avg_price: float = 0.0
@@ -71,23 +103,23 @@ class ICEPowerExchange:
             avg_price = float(o.get("avg_price", 0))
             if status == "FILLED":
                 break
-            elif status in ("CANCELLED", "REJECTED"):
+            if status in ("CANCELLED", "REJECTED"):
                 break
             time.sleep(settings.order_poll_interval)
-
         else:
-            # timed out: cancel
             self.cancel_order(order_id)
 
         return Fill(qty_mwh=filled, price=avg_price, order_id=order_id)
 
     def sell(self, qty_mwh: float) -> Fill:
-        # market‐sell (no price cap)
+        bid, ask = self._fetch_orderbook()
+        target_price = bid if bid is not None else 0.0
         payload = {
             "symbol":   self.symbol,
             "side":     "SELL",
             "quantity": qty_mwh,
-            "type":     "MARKET",
+            "price":    target_price,
+            "type":     "LIMIT",
         }
         resp = self.session.post(
             f"{self.base_url}/orders", json=payload, timeout=DEFAULT_TIMEOUT
@@ -96,7 +128,6 @@ class ICEPowerExchange:
         order = resp.json()
         order_id = order["id"]
 
-        # poll same as buy
         deadline = time.time() + settings.order_timeout_secs
         filled = 0.0
         avg_price = 0.0
@@ -114,14 +145,50 @@ class ICEPowerExchange:
 
         return Fill(qty_mwh=filled, price=avg_price, order_id=order_id)
 
-    def _fetch_order(self, order_id: str) -> dict:
-        resp = self.session.get(
-            f"{self.base_url}/orders/{order_id}", timeout=DEFAULT_TIMEOUT
+
+class ICERepoFuturesExchange(_ICERestBase):
+    """Futures leg mapped to ICE REST orderbook + order entry."""
+
+    def quote(self) -> float:
+        bid, _ = self._fetch_orderbook()
+        if bid is None:
+            raise RuntimeError("ICE orderbook has no bids; cannot price SELL leg")
+        return bid
+
+    def sell(self, qty_mwh: float) -> Fill:
+        bid, _ = self._fetch_orderbook()
+        if bid is None:
+            raise RuntimeError("ICE orderbook has no bids; cannot execute SELL leg")
+
+        payload = {
+            "symbol":   self.symbol,
+            "side":     "SELL",
+            "quantity": qty_mwh,
+            "price":    bid,
+            "type":     "LIMIT",
+        }
+        resp = self.session.post(
+            f"{self.base_url}/orders", json=payload, timeout=DEFAULT_TIMEOUT
         )
         resp.raise_for_status()
-        return resp.json()
+        order = resp.json()
+        order_id = order["id"]
 
-    def cancel_order(self, order_id: str) -> None:
-        self.session.delete(
-            f"{self.base_url}/orders/{order_id}", timeout=DEFAULT_TIMEOUT
-        )
+        deadline = time.time() + settings.order_timeout_secs
+        filled = 0.0
+        avg_price = 0.0
+
+        while time.time() < deadline:
+            o = self._fetch_order(order_id)
+            status = o["status"]
+            filled = float(o.get("filled_qty", 0))
+            avg_price = float(o.get("avg_price", 0))
+            if status == "FILLED":
+                break
+            if status in ("CANCELLED", "REJECTED"):
+                break
+            time.sleep(settings.order_poll_interval)
+        else:
+            self.cancel_order(order_id)
+
+        return Fill(qty_mwh=filled, price=avg_price, order_id=order_id)

--- a/app/exchange_repo.py
+++ b/app/exchange_repo.py
@@ -1,0 +1,61 @@
+import requests
+
+from app.config import settings
+from app.exchange import Fill
+
+DEFAULT_TIMEOUT = 10
+
+
+class FnalityRepoExchange:
+    """Adapter for Fnality×HQLAˣ intraday repo order books."""
+
+    def __init__(self) -> None:
+        self.base_url = settings.fnality_repo_api_url
+        self.api_token = settings.fnality_repo_api_token
+        self.market = settings.fnality_repo_market
+
+        required = (self.base_url, self.api_token, self.market)
+        if not all(required):
+            raise RuntimeError("Missing Fnality/HQLAˣ repo config")
+
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {self.api_token}",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def advance(self) -> None:
+        # live order book polled on demand
+        return None
+
+    def _best_bid(self) -> float:
+        resp = self.session.get(
+            f"{self.base_url}/markets/{self.market}/orderbook", timeout=DEFAULT_TIMEOUT
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        bids = body.get("bids") or []
+        if not bids:
+            raise RuntimeError("Fnality/HQLAˣ orderbook has no bids")
+        top = bids[0]
+        return float(top["price"])
+
+    def quote(self) -> float:
+        return self._best_bid()
+
+    def sell(self, qty_mwh: float) -> Fill:
+        price = self._best_bid()
+        payload = {
+            "market": self.market,
+            "side": "SELL",
+            "quantity_mwh": qty_mwh,
+            "price": price,
+        }
+        resp = self.session.post(
+            f"{self.base_url}/orders", json=payload, timeout=DEFAULT_TIMEOUT
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        return Fill(qty_mwh=qty_mwh, price=price, order_id=body.get("id"))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,20 @@ def test_ice_live_requires_all_fields():
         _settings(use_ice_live=True, ice_api_url=None)
 
 
+def test_fnality_repo_adapter_requires_credentials():
+    with pytest.raises(ValueError, match="Fnality/HQLAˣ repo config"):
+        _settings(
+            use_ice_live=True,
+            futures_live_adapter="fnality_repo",
+            ice_api_url="https://ice.example",  # required for the power leg
+            ice_api_key="k",
+            ice_api_secret="s",
+            fnality_repo_api_url=None,
+            fnality_repo_api_token=None,
+            fnality_repo_market=None,
+        )
+
+
 def test_web3_loan_requires_credentials():
     with pytest.raises(ValueError, match="USE_WEB3_LOAN=1"):
         _settings(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -104,7 +104,7 @@ def test_run_cycle_records_trade(monkeypatch):
     power = StaticPower(quote_price=10.0)
     futures = StaticFutures(quote_price=50.0)
     monkeypatch.setattr(orchestrator, "POWER", power)
-    monkeypatch.setattr(orchestrator, "ice", futures)
+    monkeypatch.setattr(orchestrator, "FUTURES", futures)
 
     executed = orchestrator.run_cycle()
     assert executed is True
@@ -133,7 +133,7 @@ def test_run_cycle_blocks_notional(monkeypatch):
     power = StaticPower(quote_price=5.0)
     futures = StaticFutures(quote_price=10.0)
     monkeypatch.setattr(orchestrator, "POWER", power)
-    monkeypatch.setattr(orchestrator, "ice", futures)
+    monkeypatch.setattr(orchestrator, "FUTURES", futures)
 
     executed = orchestrator.run_cycle()
     assert executed is False

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -58,9 +58,9 @@ def test_daily_loss_cap(monkeypatch):
 
     monkeypatch.setattr("app.orchestrator.should_trade", fake_should_trade)
     monkeypatch.setattr("app.orchestrator.POWER.quote", lambda: 10_000.0)
-    monkeypatch.setattr("app.orchestrator.ice.quote", lambda: 9_999.0)
+    monkeypatch.setattr("app.orchestrator.FUTURES.quote", lambda: 9_999.0)
     monkeypatch.setattr("app.orchestrator.POWER.buy", lambda *_, **__: Fill(-20.0))
-    monkeypatch.setattr("app.orchestrator.ice.sell", lambda *_, **__: Fill(-30.0))
+    monkeypatch.setattr("app.orchestrator.FUTURES.sell", lambda *_, **__: Fill(-30.0))
     monkeypatch.setattr("app.orchestrator.save_order", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("app.orchestrator.save_trade", lambda *_args, **_kwargs: None)
 


### PR DESCRIPTION
## Summary
- add configuration to choose a live futures adapter (ICE REST or Fnality×HQLAˣ) and validate required credentials
- introduce orderbook-aware ICE and Fnality repo exchange adapters and wire the orchestrator to the new FUTURES abstraction
- adjust tests for the pluggable futures leg and new configuration validation

## Testing
- PYTHONPATH=. poetry run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bbd9ba510832794a4d0ed47ed5432)