### PR TITLE
Add macOS starter script and Automator guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,47 @@ Then browse to `http://localhost:8000/ui` to:
 - Fetch `/healthz`, `/pnl`, `/trades`, `/orders/open`, and `/metrics` data
   directly from the browser.
 
+### One-click macOS starter
+
+The repository ships with a macOS helper that applies the latest `git` changes,
+runs `poetry install`, loads your `.env`, starts uvicorn in the background, and
+opens the control panel:
+
+```bash
+./scripts/start_macos.sh
+```
+
+Notes:
+
+- The script exits early with an actionable message when Poetry is not
+  installed (install via `pipx install poetry` on macOS).
+- It expects a populated `.env` in the repo root. Set `ENV_FILE=/path/to/.env`
+  to point to a different file. A simple preflight enforces `API_KEY` by
+  default; disable it with `PREFLIGHT=0` if you are only exploring the UI.
+- Uvicorn logs stream to `logs/uvicorn_macos.log` and the PID is stored in
+  `logs/uvicorn.pid`.
+
+### Create a double-clickable macOS app
+
+Wrap `scripts/start_macos.sh` in an Automator Application so operators can
+launch the API + UI from a desktop icon:
+
+1. Open **Automator** → **New Document** → choose **Application**.
+2. Add a **Run Shell Script** action.
+   - Shell: `/bin/bash`
+   - Pass input: *to stdin*
+   - Script contents:
+
+     ```bash
+     /bin/bash /ABSOLUTE/PATH/TO/flash-green-poc/scripts/start_macos.sh
+     ```
+
+3. Save the application as `Flash Green API.app` (e.g., in `~/Applications`).
+4. Right-click the saved app → **Make Alias**, then drag the alias to your
+   Desktop for one-click access to `http://localhost:8000/ui`.
+5. Double-click the Desktop alias to pull the latest code, refresh dependencies,
+   and open the control panel in your default browser.
+
 ### Environment templates
 
 | File | When to use | Highlights |

--- a/scripts/start_macos.sh
+++ b/scripts/start_macos.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v poetry >/dev/null 2>&1; then
+  cat <<'MSG'
+Poetry is required to start flash-green-poc.
+Install it with pipx (`pipx install poetry`) or follow https://python-poetry.org/docs/#installation,
+then re-run this starter.
+MSG
+  exit 1
+fi
+
+echo "Updating repository at $REPO_ROOT..."
+git pull --rebase
+
+echo "Installing/updating Python dependencies with Poetry..."
+poetry install
+
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env}"
+REQUIRED_VARS=("API_KEY")
+
+if [[ "${PREFLIGHT:-1}" == "1" ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Missing environment file: $ENV_FILE"
+    echo "Copy env.staging.example or env.production.example to .env and fill in required values first."
+    exit 1
+  fi
+
+  missing_vars=()
+  while IFS= read -r var_name; do
+    missing_vars+=("$var_name")
+  done < <(for var in "${REQUIRED_VARS[@]}"; do
+    if ! grep -Eq "^[[:space:]]*${var}=" "$ENV_FILE"; then
+      echo "$var"
+    fi
+  done)
+
+  if (( ${#missing_vars[@]} )); then
+    echo "The following required settings are missing in $ENV_FILE: ${missing_vars[*]}"
+    echo "Populate them before starting the API/UI server."
+    exit 1
+  fi
+fi
+
+echo "Loading environment from $ENV_FILE..."
+set -a
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+set +a
+
+LOG_DIR="${LOG_DIR:-$REPO_ROOT/logs}"
+mkdir -p "$LOG_DIR"
+UVICORN_LOG="$LOG_DIR/uvicorn_macos.log"
+
+if pgrep -f "uvicorn app.web:api" >/dev/null 2>&1; then
+  echo "A uvicorn process for app.web:api is already running. Check $UVICORN_LOG if this is unexpected."
+else
+  echo "Starting uvicorn (logs: $UVICORN_LOG)..."
+  nohup poetry run uvicorn app.web:api --host 0.0.0.0 --port 8000 >"$UVICORN_LOG" 2>&1 &
+  SERVER_PID=$!
+  echo "$SERVER_PID" > "$LOG_DIR/uvicorn.pid"
+  echo "Started uvicorn with PID $SERVER_PID"
+fi
+
+if command -v open >/dev/null 2>&1; then
+  echo "Opening http://localhost:8000/ui in your browser..."
+  open "http://localhost:8000/ui" >/dev/null 2>&1 &
+else
+  echo "Please open http://localhost:8000/ui manually."
+fi


### PR DESCRIPTION
## Summary
- add a macOS helper script that pulls the repo, installs dependencies, loads .env, and launches uvicorn with the UI
- handle missing Poetry with a clear message and log background server output for troubleshooting
- document one-click usage plus Automator application wrapping and desktop alias setup in README

## Testing
- bash -n scripts/start_macos.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd6e73a3c832791fe4529b8c1ba78)