### PR TITLE
Update live config placeholders for energy feeds

### DIFF
--- a/app/static/ui.html
+++ b/app/static/ui.html
@@ -304,11 +304,13 @@
           </div>
           <div>
             <label for="liveExchange">LIVE_EXCHANGE</label>
-            <input id="liveExchange" type="text" placeholder="binance" />
+            <input id="liveExchange" type="text" placeholder="ice" />
+            <p class="muted hint">Adapter name, e.g. <code>ice</code> or <code>powerledger</code>.</p>
           </div>
           <div>
             <label for="liveSymbol">LIVE_SYMBOL</label>
-            <input id="liveSymbol" type="text" placeholder="BTC/USDT" />
+            <input id="liveSymbol" type="text" placeholder="N2EX_BASE_M1" />
+            <p class="muted hint">Energy contract symbol (no crypto pairs), e.g. <code>NBP_GAS_Q4_2024</code>.</p>
           </div>
           <div>
             <label for="powerledgerApiUrl">POWERLEDGER_API_URL</label>


### PR DESCRIPTION
## Summary
- update LIVE_EXCHANGE placeholder and hint to reference ICE/Powerledger adapters
- refresh LIVE_SYMBOL placeholder and hint to show energy contract examples instead of crypto pairs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bdfba6a5483279729a66683e3e0df)