### PR TITLE
Add graph-based route selection for trading cycles

### DIFF
--- a/app/strategy.py
+++ b/app/strategy.py
@@ -1,14 +1,40 @@
 # app/strategy.py
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
 
 from app.config import settings
 from app.logger import logger
 
 
-def kelly_size(
-    spread: float,
-    stdev: float = 35,
-    bank: float = 50_000,
-) -> float:
+@dataclass
+class Edge:
+    source: str
+    target: str
+    rate: float
+
+
+@dataclass
+class QuoteSnapshot:
+    spot_price: float
+    futures_price: float
+    slippage_bp: float = settings.slippage_bp
+    loan_fee_rate: float = 0.0
+
+
+@dataclass
+class TradePlan:
+    execute: bool
+    qty_mwh: float = 0.0
+    spread: float = 0.0
+    expected_profit: float = 0.0
+    path: list[str] | None = None
+    block_reason: str | None = None
+
+
+def kelly_size(spread: float, stdev: float = 35, bank: float = 50_000) -> float:
     """Return a crude Kelly position size in MWh."""
 
     f_star = spread / (stdev**2)
@@ -16,28 +42,113 @@ def kelly_size(
     return size_fraction * bank / spread
 
 
-def should_trade(spot: float, futs: float) -> tuple[bool, float, float]:
-    """
-    Decide whether to trade this tick.
-    Returns (trade_flag, qty_mwh, spread).
-    """
-    spread = futs - spot
+def _build_edges(quotes: QuoteSnapshot) -> list[Edge]:
+    if quotes.spot_price <= 0 or quotes.futures_price <= 0:
+        raise ValueError("Quotes must be positive")
 
-    # --- DEBUG: log inputs and thresholds ---
-    logger.debug(
-        "STRATEGY spot=%.2f futs=%.2f spread=%.2f neg=%s min=%s",
-        spot,
-        futs,
-        spread,
-        settings.neg_threshold,
-        settings.spread_min,
-    )
+    slip = max(quotes.slippage_bp, 0) / 10_000
+    buy_price = quotes.spot_price * (1 + slip)
+    sell_price = quotes.futures_price * (1 - slip)
+    loan_multiplier = max(0.0, 1 - quotes.loan_fee_rate)
 
-    # Trading condition
-    if spot <= settings.neg_threshold and spread >= settings.spread_min:
-        qty = kelly_size(spread)
-        logger.debug("STRATEGY ⇒ trade=True qty=%.4f", qty)
-        return True, qty, spread
+    edges = [
+        Edge("GBP", "MWH", rate=1 / buy_price),
+        Edge("MWH", "GBP", rate=sell_price),
+        Edge("GBP", "GBP", rate=loan_multiplier),
+    ]
+    return edges
 
-    logger.debug("STRATEGY ⇒ trade=False")
-    return False, 0.0, spread
+
+def _bellman_ford(nodes: Sequence[str], edges: Sequence[Edge], source: str) -> list[str] | None:
+    dist = {node: math.inf for node in nodes}
+    pred: dict[str, str | None] = {node: None for node in nodes}
+    dist[source] = 0
+
+    weights = {(edge.source, edge.target): -math.log(edge.rate) for edge in edges}
+
+    for _ in range(len(nodes) - 1):
+        updated = False
+        for edge in edges:
+            weight = weights[(edge.source, edge.target)]
+            if dist[edge.source] + weight < dist[edge.target]:
+                dist[edge.target] = dist[edge.source] + weight
+                pred[edge.target] = edge.source
+                updated = True
+        if not updated:
+            break
+
+    for edge in edges:
+        weight = weights[(edge.source, edge.target)]
+        if dist[edge.source] + weight < dist[edge.target]:
+            cycle_start = edge.target
+            for _ in range(len(nodes)):
+                cycle_start = pred.get(cycle_start) or cycle_start
+            cycle = [cycle_start]
+            node = pred.get(cycle_start)
+            while node is not None and node not in cycle:
+                cycle.append(node)
+                node = pred.get(node)
+            cycle.append(cycle[0])
+            cycle.reverse()
+            return cycle
+
+    return None
+
+
+def _cycle_rate(path: Iterable[str], edges: Sequence[Edge]) -> float:
+    edge_map = {(edge.source, edge.target): edge for edge in edges}
+    nodes = list(path)
+    if len(nodes) < 2:
+        return 1.0
+
+    rate = 1.0
+    for left, right in zip(nodes, nodes[1:]):
+        edge = edge_map.get((left, right))
+        if edge is None:
+            return 0.0
+        rate *= edge.rate
+    return rate
+
+
+def select_route(quotes: QuoteSnapshot) -> TradePlan:
+    edges = _build_edges(quotes)
+    nodes = sorted({edge.source for edge in edges} | {edge.target for edge in edges})
+
+    spread = quotes.futures_price - quotes.spot_price
+    cycle = _bellman_ford(nodes, edges, source="GBP")
+    if not cycle:
+        logger.debug("No negative cycle detected")
+        return TradePlan(False, 0.0, spread, 0.0, [], None)
+
+    cycle_rate = _cycle_rate(cycle, edges)
+    slip = max(quotes.slippage_bp, 0) / 10_000
+    buy_price = quotes.spot_price * (1 + slip)
+    sell_price = quotes.futures_price * (1 - slip)
+    loan_multiplier = max(0.0, 1 - quotes.loan_fee_rate)
+
+    profit_per_mwh = sell_price * loan_multiplier - buy_price
+    if cycle_rate <= 1 or profit_per_mwh <= 0:
+        logger.debug(
+            "Cycle rejected: rate=%.6f profit/mwh=%.4f path=%s",
+            cycle_rate,
+            profit_per_mwh,
+            cycle,
+        )
+        return TradePlan(False, 0.0, spread, 0.0, cycle, None)
+
+    qty = kelly_size(profit_per_mwh, bank=settings.kelly_bank_gbp)
+    max_notional = min(settings.max_notional_per_trade, settings.loan_limit_gbp)
+    notional = qty * buy_price
+
+    if notional > max_notional:
+        logger.debug(
+            "Notional %.2f above cap %.2f; skipping trade", notional, max_notional
+        )
+        return TradePlan(False, 0.0, spread, 0.0, cycle, "notional")
+
+    if qty <= 0:
+        logger.debug("Zero position after risk caps; skipping")
+        return TradePlan(False, 0.0, spread, 0.0, cycle, None)
+
+    expected_profit = qty * (sell_price * loan_multiplier + buy_price)
+    return TradePlan(True, qty, profit_per_mwh, expected_profit, list(cycle), None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,14 +1,15 @@
 from datetime import timedelta
 
-from app.config import settings
 import app.orchestrator as orch
 from app.orchestrator import run_cycle
+from app.strategy import TradePlan
+from app.config import settings
 
 
 def test_notional_block(monkeypatch):
     monkeypatch.setattr(
-        "app.orchestrator.should_trade",
-        lambda *_: (True, 2.0, 0.0),
+        "app.orchestrator.select_route",
+        lambda *_: TradePlan(True, 2.0, 0.0, 0.0, []),
     )
     monkeypatch.setattr("app.orchestrator.POWER.quote", lambda: 10_000.0)
     settings.max_notional_per_trade = 1.0
@@ -24,8 +25,8 @@ def test_daily_loss_reset(monkeypatch):
         lambda: orch._current_day + timedelta(days=1),
     )
     monkeypatch.setattr(
-        "app.orchestrator.should_trade",
-        lambda *_: (False, 0, 0),
+        "app.orchestrator.select_route",
+        lambda *_: TradePlan(False, 0, 0, 0, []),
     )
     assert run_cycle() is False
     assert orch._daily_loss == 0.0
@@ -47,8 +48,8 @@ def test_daily_loss_cap(monkeypatch):
 
     blocked_start = orch.METRICS.trades_blocked._value.get()
 
-    def fake_should_trade(*_):
-        return True, 1.0, 0.0
+    def fake_select_route(*_):
+        return TradePlan(True, 1.0, 0.0, 0.0, [])
 
     class Fill:
         def __init__(self, price: float):
@@ -56,7 +57,7 @@ def test_daily_loss_cap(monkeypatch):
             self.qty_mwh = 1.0
             self.price = price
 
-    monkeypatch.setattr("app.orchestrator.should_trade", fake_should_trade)
+    monkeypatch.setattr("app.orchestrator.select_route", fake_select_route)
     monkeypatch.setattr("app.orchestrator.POWER.quote", lambda: 10_000.0)
     monkeypatch.setattr("app.orchestrator.FUTURES.quote", lambda: 9_999.0)
     monkeypatch.setattr("app.orchestrator.POWER.buy", lambda *_, **__: Fill(-20.0))
@@ -71,9 +72,9 @@ def test_daily_loss_cap(monkeypatch):
 
     def should_not_run(*_):
         call_count["calls"] += 1
-        return True, 1.0, 0.0
+        return TradePlan(True, 1.0, 0.0, 0.0, [])
 
-    monkeypatch.setattr("app.orchestrator.should_trade", should_not_run)
+    monkeypatch.setattr("app.orchestrator.select_route", should_not_run)
 
     assert run_cycle() is False
     assert call_count["calls"] == 0

--- a/tests/test_spread.py
+++ b/tests/test_spread.py
@@ -1,7 +1,29 @@
-# tests/test_spread.py
-from app.strategy import should_trade
+import pytest
+
+from app.strategy import QuoteSnapshot, select_route
 
 
-def test_trigger():
-    assert should_trade(-5, 70)[0]
-    assert not should_trade(10, 68)[0]
+def test_select_route_detects_profitable_cycle():
+    quotes = QuoteSnapshot(spot_price=10.0, futures_price=50.0, slippage_bp=0.0)
+    plan = select_route(quotes)
+
+    assert plan.execute is True
+    assert plan.path[0] == plan.path[-1]
+    assert plan.expected_profit > 0
+
+
+def test_select_route_blocks_unprofitable_cycle():
+    quotes = QuoteSnapshot(spot_price=50.0, futures_price=50.0, slippage_bp=0.0, loan_fee_rate=0.2)
+    plan = select_route(quotes)
+
+    assert plan.execute is False
+    assert plan.expected_profit == 0
+
+
+def test_select_route_rejects_bad_input():
+    quotes = QuoteSnapshot(spot_price=-1.0, futures_price=20.0, slippage_bp=0.0)
+
+    select_route(QuoteSnapshot(spot_price=1.0, futures_price=20.0, slippage_bp=0.0))
+
+    with pytest.raises(ValueError):
+        select_route(quotes)


### PR DESCRIPTION
## Summary
- add Bellman-Ford-based route selection that factors slippage, loan costs, and notional caps
- wire orchestrator to use the new trade planning output and track blocked trades
- add regression tests for route selection, orchestrator paths, and shared test configuration

## Testing
- poetry run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691be05a81b083278ed648b0b88beaac)