### PR TITLE
Enforce mandatory API_KEY configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ legs confirm—mirroring a flash-loan pattern.
 1. Pick the closest environment template (`env.staging.example` or
    `env.production.example`).
 2. Copy it to `.env` (or the location you pass to `Settings`).
-3. Fill in the placeholders for the features you are enabling.
+3. Fill in the placeholders for the features you are enabling. **`API_KEY` is
+   mandatory**; the FastAPI app refuses to start if it is missing or empty.
 4. Optional – point `SECRETS_BACKEND` at Vault or AWS Secrets Manager if you do
    not want secrets committed to disk.
 
@@ -29,11 +30,13 @@ app.orchestrator` will load the `.env` file automatically.
 
 API endpoints that expose metrics or trading data require a shared secret in the
 `X-API-Key` header. Set `API_KEY` in your `.env` (or secret manager) and pass it
-with each request to `/metrics`, `/pnl`, `/trades`, and `/orders/open`. The
-control-plane endpoints that start/stop the orchestrator or run tests **refuse
-all requests** when `API_KEY` is missing or incorrect and are rate limited with
-audit logging. See `docs/deployment.md` for the minimum security checklist
-before exposing the service.
+with each request to `/metrics`, `/pnl`, `/trades`, and `/orders/open`. The API
+will fail FastAPI initialisation if `API_KEY` is not set and will return `503`
+for any request when the key is missing. The control-plane endpoints that
+start/stop the orchestrator or run tests **refuse all requests** when `API_KEY`
+is missing or incorrect and are rate limited with audit logging. See
+`docs/deployment.md` for the minimum security checklist before exposing the
+service.
 
 ## Local API + UI
 
@@ -142,7 +145,8 @@ running outside the UTC window or during Saturday/Sunday if the weekend flag is
 off.
 
 Any missing credential raises a `ValueError` during `Settings` initialisation.
-This prevents the orchestrator from starting if a release misses an env var.
+This prevents the orchestrator from starting if a release misses an env var –
+including the mandatory `API_KEY`.
 
 ### Tests
 

--- a/app/config.py
+++ b/app/config.py
@@ -461,6 +461,12 @@ class Settings(BaseSettings):
 
         return model
 
+    @model_validator(mode="after")
+    def _require_api_key(cls, model: "Settings") -> "Settings":
+        if not model.api_key:
+            raise ValueError("API_KEY is required for all deployments")
+        return model
+
     class Config:
         env_file_encoding = "utf-8"
         case_sensitive = False

--- a/app/web.py
+++ b/app/web.py
@@ -86,8 +86,11 @@ async def require_api_key(
     expected_key = settings.api_key
 
     if not expected_key:
-        logger.warning("API_KEY is not configured; skipping authentication")
-        return ""
+        logger.error("API_KEY is not configured; refusing to serve requests")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="API_KEY is not configured",
+        )
 
     if not x_api_key or x_api_key != expected_key:
         raise HTTPException(

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,12 +4,12 @@ These steps harden the Flash-Green API before exposing it to any operators.
 
 ## Configure authentication
 
-- **Set `API_KEY`** in the runtime environment before starting the FastAPI service. Requests that mutate state (e.g., orchestrator start/stop, test execution) are rejected when the header `X-API-Key` is missing or does not match `API_KEY`.
+- **Set `API_KEY`** in the runtime environment before starting the FastAPI service. The API will fail to initialize without it, and a misconfigured deployment returns `503` for all dependency-injected routes. Requests that mutate state (e.g., orchestrator start/stop, test execution) are rejected when the header `X-API-Key` is missing or does not match `API_KEY`.
 - If you use stronger auth (mTLS, OIDC), enforce it at the proxy or ingress layer and keep the API key check enabled as a defense in depth unless you explicitly replace it.
 
 ## Service startup checklist
 
-1. Populate a secrets store or deployment environment with `API_KEY=<strong random value>`.
+1. Populate a secrets store or deployment environment with `API_KEY=<strong random value>`; deployments without it fail FastAPI startup.
 2. Ensure only trusted operators can reach the API service port (network ACLs/firewalls).
 3. If running behind a reverse proxy, forward the `X-API-Key` header and mTLS/OIDC identity to the FastAPI backend.
 4. Apply rate limits at the edge if available; the API also enforces per-identity limits on control-plane actions.

--- a/env.production.example
+++ b/env.production.example
@@ -49,6 +49,7 @@ HARDHAT_RPC=https://mainnet.infura.io/v3/<project-id>
 # Metrics / API ports
 METRICS_PORT=9000
 API_PORT=9002
+# Required for all deployments
 API_KEY=
 
 # Secret manager (production defaults to AWS Secrets Manager)

--- a/env.staging.example
+++ b/env.staging.example
@@ -51,6 +51,7 @@ HARDHAT_RPC=http://127.0.0.1:8545
 # Metrics / API ports
 METRICS_PORT=8000
 API_PORT=8002
+# Required for all deployments
 API_KEY=
 
 # Secret manager (staging defaults to Vault)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
+import os
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("API_KEY", "test-api-key")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,10 +7,15 @@ def _client() -> TestClient:
     return TestClient(api)
 
 
+def _auth_headers(value: str | None = None) -> dict[str, str]:
+    key = value if value is not None else settings.api_key
+    return {"X-API-Key": key or ""}
+
+
 def test_trades_endpoint_empty(monkeypatch):
     monkeypatch.setattr("app.web.get_trades", lambda limit, conn=None: [])
     client = _client()
-    resp = client.get("/trades")
+    resp = client.get("/trades", headers=_auth_headers())
     assert resp.status_code == 200
     assert resp.json() == []
 
@@ -22,12 +27,14 @@ def test_protected_endpoints_require_api_key_when_configured(monkeypatch):
     resp_missing = client.get("/pnl")
     assert resp_missing.status_code == 401
 
-    resp_valid = client.get("/pnl", headers={"X-API-Key": "secret-key"})
+    resp_invalid = client.get("/pnl", headers=_auth_headers("wrong-key"))
+    assert resp_invalid.status_code == 401
+
+    resp_valid = client.get("/pnl", headers=_auth_headers("secret-key"))
     assert resp_valid.status_code == 200
 
 
 def test_pnl_totals_are_returned(monkeypatch):
-    monkeypatch.setattr(settings, "api_key", None)
     monkeypatch.setattr(
         "app.web.get_pnl_totals",
         lambda conn=None: {"net": 5.0, "positive": 8.0, "negative": 3.0},
@@ -35,6 +42,15 @@ def test_pnl_totals_are_returned(monkeypatch):
 
     client = _client()
 
-    resp = client.get("/pnl")
+    resp = client.get("/pnl", headers=_auth_headers())
     assert resp.status_code == 200
     assert resp.json() == {"net": 5.0, "positive": 8.0, "negative": 3.0}
+
+
+def test_requests_fail_when_api_key_not_configured(monkeypatch):
+    monkeypatch.setattr(settings, "api_key", None)
+    client = _client()
+
+    resp = client.get("/pnl", headers=_auth_headers("any"))
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "API_KEY is not configured"


### PR DESCRIPTION
## Summary
- enforce API_KEY validation at startup and return HTTP errors when misconfigured
- document that API_KEY is mandatory across README, deployment guide, and env templates
- add authentication tests and ensure config fixtures include required API key

## Testing
- poetry run pytest tests/test_api.py tests/test_config.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c19003bf083278b13d90a8bd8b816)