### PR TITLE
Add deployment preflight validation and ops runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -12,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -24,22 +28,55 @@ jobs:
       - name: Run tests
         run: poetry run pytest -q
 
-  build-and-publish:
+  preflight:
     needs: lint-and-test
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+      CLIENT_CERT_SUBJECT_HEADER: ci-preflight
+      DATABASE_URL: sqlite:///:memory:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Build Docker image
+      - name: Fail when critical secrets are absent
         run: |
-          docker build -t yourorg/flash-green-poc:${{ github.sha }} .
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+          if [ -z "${API_KEY:-}" ]; then
+            echo "API_KEY must be provided via repository secrets" >&2
+            exit 1
+          fi
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push image
+          python-version: "3.11"
+      - name: Install dependencies
         run: |
-          docker push yourorg/flash-green-poc:${{ github.sha }}
+          pip install poetry
+          poetry install
+      - name: Run deployment preflight
+        run: |
+          poetry run python scripts/preflight_check.py
+
+  build-and-publish:
+    needs: [lint-and-test, preflight]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ including the mandatory `API_KEY`.
 Configuration regressions are caught via `pytest -k config`, which instantiates
 `Settings` under multiple feature combinations.
 
+### Deployment preflight
+
+- Validate deployment inputs before rollout: `python scripts/preflight_check.py --env-file .env`.
+- Operational procedures for rollout/rollback, telemetry, and backups are documented in `docs/runbook.md`.
+
 ## Operational runbooks (atomic energy-versus-futures arbitrage)
 
 ### Live Powerledger + ICE connectivity

--- a/app/web.py
+++ b/app/web.py
@@ -551,24 +551,27 @@ async def ui_service_start(
             detail="Custom commands or env overrides are not supported in supervised mode",
         )
 
-    status = _orchestrator_status()
-    if status.get("running"):
-        return {"detail": "orchestrator already running", **status}
+    orchestrator_status = _orchestrator_status()
+    if orchestrator_status.get("running"):
+        return {"detail": "orchestrator already running", **orchestrator_status}
 
     _supervisor.start()
-    status = _orchestrator_status()
+    orchestrator_status = _orchestrator_status()
 
     _audit_log(
-        action="/ui/services/start", request=request, principal=principal, status=status
+        action="/ui/services/start",
+        request=request,
+        principal=principal,
+        status=orchestrator_status,
     )
-    return {"detail": "orchestrator started", **status}
+    return {"detail": "orchestrator started", **orchestrator_status}
 
 
 @api.post("/ui/services/stop")
 async def ui_service_stop(request: Request, principal: Principal = Depends(control_plane_guard)):
-    status = _orchestrator_status()
-    if not status.get("running") and not status.get("supervisor_running"):
-        return {"detail": "orchestrator already stopped", **status}
+    orchestrator_status = _orchestrator_status()
+    if not orchestrator_status.get("running") and not orchestrator_status.get("supervisor_running"):
+        return {"detail": "orchestrator already stopped", **orchestrator_status}
 
     _supervisor.stop()
     stopped = _orchestrator_status()

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,39 @@
+# Operations Runbook
+
+This runbook captures the actions and expectations for shipping and operating Flash Green across environments.
+
+## Preflight and rollout
+1. **Populate environment variables** using the appropriate template (`env.staging.example` or `env.production.example`). Ensure the following are present before rollout:
+   - `API_KEY` plus either `CLIENT_CERT_SUBJECT_HEADER` or the `OIDC_ISSUER`/`OIDC_AUDIENCE` pair.
+   - Database coordinates (`DATABASE_URL` or the `DB_*` trio), and any live adapters you plan to enable (`USE_LIVE_FEED`, `USE_ICE_LIVE`, `USE_POWERLEDGER_LIVE`, `USE_WEB3_LOAN`).
+   - Secret backend settings when used: `VAULT_ADDR`/`VAULT_TOKEN`/`VAULT_SECRET_PATH` for Vault, or `AWS_SECRETS_REGION`/`AWS_SECRETS_ID` for AWS.
+2. **Run the preflight validator** before the first pod/task starts:
+   ```bash
+   python scripts/preflight_check.py --env-file /path/to/.env
+   ```
+   This fails fast if critical env vars are empty, secrets cannot be loaded, or the database is unreachable.
+3. **Deploy** (Helm/k8s, ECS task, or Docker Compose). The container entrypoint also executes the same preflight before applying migrations and launching services.
+
+## Rollback
+1. Stop the newly deployed task/pod version and redeploy the last known-good image tag (e.g., `:previous` or a pinned SHA).
+2. If migrations were applied, use Alembic to downgrade to the prior revision:
+   ```bash
+   alembic downgrade -1
+   ```
+3. Verify the service returns healthy status and reconciles order flows before re-opening traffic.
+
+## Logging and metrics
+- **Application logs:** emitted to stdout/stderr and collected by the platform log shipper (e.g., Kubernetes sidecar or ECS FireLens). Ensure log routing points to the central SIEM/observability stack used by your environment.
+- **Metrics:** Prometheus-format metrics are exposed on `:${METRICS_PORT:-8000}/metrics`. Scrape via Prometheus/Grafana Agent or configure an OpenMetrics scrape in your collector.
+
+## Database backup/restore
+- **Engine:** PostgreSQL is the default managed database. Use your platform backup tooling (e.g., RDS snapshots) or scheduled `pg_dump` exports.
+- **Ad-hoc backup:**
+  ```bash
+  pg_dump "$DATABASE_URL" > flash-green-backup.sql
+  ```
+- **Restore:**
+  ```bash
+  psql "$DATABASE_URL" < flash-green-backup.sql
+  ```
+- **Validation:** After restores, rerun `python scripts/preflight_check.py` to ensure connectivity and launch the service in read-only mode to confirm data integrity before resuming trading.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+python /app/scripts/preflight_check.py
+
 alembic upgrade head
 
 exec python -m app.orchestrator

--- a/scripts/preflight_check.py
+++ b/scripts/preflight_check.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Preflight validation for deployments and CI.
+
+This script validates the environment configuration, optional secret backends,
+any live adapter requirements, and database connectivity before starting the
+services. It exits non-zero on failure so callers can fail fast during deploys
+or builds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sqlalchemy import create_engine, text
+
+from app.config import Settings
+
+
+def _load_env_file(env_file: Path) -> None:
+    """Load key/value pairs from an ``.env`` file when present."""
+
+    if not env_file.exists():
+        raise FileNotFoundError(f"Missing env file: {env_file}")
+
+    dotenv_spec = importlib.util.find_spec("dotenv")
+    if dotenv_spec is not None:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file)
+        return
+
+    for line in env_file.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", maxsplit=1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+def _fail_if_missing(vars_to_check: Iterable[str]) -> None:
+    missing = [name for name in vars_to_check if os.environ.get(name) in (None, "")]
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise SystemExit(f"Required environment variables are missing: {joined}")
+
+
+def _check_database(url: str) -> None:
+    engine = create_engine(url, pool_pre_ping=True, future=True)
+    with engine.connect() as connection:
+        connection.execute(text("SELECT 1"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate deployment prerequisites")
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        help="Optional .env file to load before validation",
+    )
+    parser.add_argument(
+        "--skip-db",
+        action="store_true",
+        help="Skip database connectivity check",
+    )
+    args = parser.parse_args()
+
+    if args.env_file:
+        _load_env_file(args.env_file)
+
+    _fail_if_missing(["API_KEY"])
+
+    try:
+        settings = Settings()
+    except Exception as exc:  # pragma: no cover - validated via integration usage
+        raise SystemExit(f"Settings validation failed: {exc}") from exc
+
+    if not args.skip_db:
+        try:
+            _check_database(settings.database_url)
+        except Exception as exc:  # pragma: no cover - depends on target DB
+            raise SystemExit(f"Database connectivity failed: {exc}") from exc
+
+    print("Preflight checks passed:")
+    print(f"- Identity: {'OIDC' if settings.oidc_issuer else 'mTLS header'} configured")
+    print(f"- Secrets backend: {settings.secrets_backend or 'environment' }")
+    print(f"- Live feed enabled: {settings.use_live_feed}")
+    print(f"- ICE live enabled: {settings.use_ice_live}")
+    print(f"- Powerledger live enabled: {settings.use_powerledger_live}")
+    print(f"- Web3 loan enabled: {settings.use_web3_loan}")
+    if not args.skip_db:
+        print(f"- Database reachable at {settings.database_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 os.environ.setdefault("API_KEY", "test-key")
+os.environ.setdefault("CLIENT_CERT_SUBJECT_HEADER", "X-SSL-Client-Subject")
+os.environ.setdefault("FORWARDED_PROTO_HEADER", "x-forwarded-proto")
+os.environ.setdefault("REQUIRE_HTTPS", "0")
 
 import app.db as db
 import app.storage as storage


### PR DESCRIPTION
## Summary
- add a deployment preflight script and run it in the container entrypoint to fail fast on missing secrets or DB connectivity
- expand CI with a preflight job and GHCR publish step alongside linting/tests
- document rollout/rollback/backup steps and align tests with the supervised UI start flow

## Testing
- poetry run pytest -q
- CLIENT_CERT_SUBJECT_HEADER=test API_KEY=dev-key DATABASE_URL=sqlite:///./tmp.db REQUIRE_HTTPS=0 python scripts/preflight_check.py --skip-db


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c27fb9f008327a7ab888f15be2cdb)