### PR TITLE
Add atomic persistence for flash-loan trades

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -40,6 +40,10 @@ METRICS.flash_repo_rollbacks = Counter(
     "flash_repo_rollbacks_total",
     "Rollbacks triggered after repo commit failures",
 )
+METRICS.trade_partial_failures = Counter(
+    "trade_partial_failures_total",
+    "Cases where one leg succeeded but persistence or hedging failed",
+)
 
 # Phase 4: risk & limits
 METRICS.daily_loss = Gauge(


### PR DESCRIPTION
## Summary
- add a transactional storage context with optional commit control for orders and trades
- stage flash-loan power/futures legs together, cancelling the order on futures failures and logging partial failures
- add coverage and metrics to verify atomic persistence paths

## Testing
- DB_URL=sqlite:///:memory: pytest tests/test_storage.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2ee46bac83278a725957e13fdb39)